### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/nested.ts
+++ b/src/nested.ts
@@ -12,6 +12,16 @@ interface ResultObjectType {
   [key: string]: ValueType | ResultObjectType | ResultArrayType;
 }
 
+/**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param {String} key key for check, string.
+ * @returns {Boolean}.
+ */
+function isPrototypePolluted(key: string): Boolean {
+  return ['__proto__', 'prototype', 'constructor'].includes(key);
+}
+
 export default function nested(object: SerializerObjectType = null): ResultObjectType {
   if (Object(object) !== object || Array.isArray(object)) {
     return object;
@@ -25,9 +35,11 @@ export default function nested(object: SerializerObjectType = null): ResultObjec
     let m;
     // tslint:disable-next-line:no-conditional-assignment
     while (m = regex.exec(key)) {
+      if (isPrototypePolluted(prop)) continue;
       cur = cur[prop] || (cur[prop] = (m[2] ? [] : {}));
       prop = m[2] || m[1];
     }
+
     cur[prop] = object[key];
   }
   return result[''] || result;


### PR DESCRIPTION
https://huntr.dev/users/d3v53c has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/nest-deep/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/nest-deep/1/README.md

### User Comments:

### 📊 Metadata *

nest-deep is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-nest-deep

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
var nestDeep = require("nest-deep")
console.log("Before : " + {}.polluted);
nestDeep.nested({"__proto__[polluted]": "Yes! Its Polluted"})
console.log("After : " + {}.polluted);
```

Execute the following commands in terminal:

```
npm i nest-deep # Install affected module
node poc.js #  Run the PoC
```

Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/102825627-26b73c00-4405-11eb-8290-0cdb86cafb43.png)

After:
![image](https://user-images.githubusercontent.com/64132745/102825668-3e8ec000-4405-11eb-8cb9-2f556a92ecc8.png)


### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-npm-nest-deep/
